### PR TITLE
fix: handle uuid terminal ids

### DIFF
--- a/src/pages/maintenance/MaintenanceTab.jsx
+++ b/src/pages/maintenance/MaintenanceTab.jsx
@@ -203,6 +203,7 @@ const MaintenanceTab = ({ technicien }) => {
       }
 
       const dataToInsert = {
+        id: crypto.randomUUID(),
         terminal_id: terminalId,
         technicien_id: technicien?.id || null,
         type_intervention: interventionData.typeIntervention,

--- a/src/pages/maintenance/MaintenanceTab.jsx
+++ b/src/pages/maintenance/MaintenanceTab.jsx
@@ -196,8 +196,8 @@ const MaintenanceTab = ({ technicien }) => {
     setIsLoading(true);
     try {
       // Préparer les données pour l'insertion
-      const terminalId = parseInt(interventionData.terminal, 10);
-      if (Number.isNaN(terminalId)) {
+      const terminalId = interventionData.terminal;
+      if (!terminalId) {
         toast({ title: 'Erreur', description: 'Terminal invalide', variant: 'destructive' });
         return false;
       }


### PR DESCRIPTION
## Summary
- ensure terminal IDs are sent without integer parsing to support uuid identifiers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/pages/maintenance/MaintenanceTab.jsx` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68c74e7116a0832d9793f69cfc39cec8