### PR TITLE
fix: add id when saving maintenance intervention

### DIFF
--- a/src/pages/maintenance/MaintenanceTab.jsx
+++ b/src/pages/maintenance/MaintenanceTab.jsx
@@ -203,6 +203,7 @@ const MaintenanceTab = ({ technicien }) => {
       }
 
       const dataToInsert = {
+        id: crypto.randomUUID(),
         terminal_id: terminalId,
         technicien_id: technicien?.id || null,
         type_intervention: interventionData.typeIntervention,


### PR DESCRIPTION
## Summary
- generate a unique id before inserting maintenance intervention

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c754e0b268832d84c21bc1ba778f03